### PR TITLE
use AbortSignal utilities instead of setTimeout

### DIFF
--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -144,7 +144,7 @@ export default class RedisCommandsQueue {
     if (this.#maxLength && this.#toWrite.length + this.#waitingForReply.length >= this.#maxLength) {
       return Promise.reject(new Error('The queue is full'));
     } else if (options?.abortSignal?.aborted) {
-      return Promise.reject(new AbortError());
+      return Promise.reject(new AbortError(options?.abortSignal?.reason));
     }
 
     return new Promise((resolve, reject) => {
@@ -165,7 +165,7 @@ export default class RedisCommandsQueue {
           signal,
           listener: () => {
             this.#toWrite.remove(node);
-            value.reject(new AbortError());
+            value.reject(new AbortError(signal.reason));
           }
         };
         signal.addEventListener('abort', value.abort.listener, { once: true });

--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -1,6 +1,6 @@
 export class AbortError extends Error {
-  constructor() {
-    super('The command was aborted');
+  constructor(message = '') {
+    super(`The command was aborted: ${message}`);
   }
 }
 
@@ -19,12 +19,6 @@ export class ConnectionTimeoutError extends Error {
 export class SocketTimeoutError extends Error {
   constructor(timeout: number) {
     super(`Socket timeout timeout. Expecting data, but didn't receive any in ${timeout}ms.`);
-  }
-}
-
-export class CommandTimeoutError extends Error {
-  constructor() {
-    super('Command timeout');
   }
 }
 


### PR DESCRIPTION
- Improve error messaging
- Remove the `CommandTimeoutError` class 
- Replace manual timeout handling with the `AbortSignal.timeout` API 
- Update related tests to align with these changes 
- Additionally, enhance the `AbortError` class to include the abort reason